### PR TITLE
Fix typo in CRUD operations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Features
 
 - Login and Logout
-- CURD Operations
+- CRUD Operations
 - Data are stored in MySql database
 - Neat and clean UI
 


### PR DESCRIPTION
“Corrected typo in README under Features section: changed ‘CURD Operations’ to ‘CRUD Operations’.”